### PR TITLE
fix(security): bump minimal version of `probot`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.2.6",
         "pino": "^6.11.0",
-        "probot": "^12.1.4",
+        "probot": "^12.2.1",
         "through2": "^4.0.2"
       },
       "devDependencies": {
@@ -6550,9 +6550,9 @@
       "dev": true
     },
     "node_modules/probot": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-12.1.4.tgz",
-      "integrity": "sha512-pbvXXeZwIdi/vWk0Xtxe78ElDvczhzEzOjWjfxINyHCAA5cHaXF7+yX/bnDRZ9O0mEJB472H/NcMrT81Uy7kVg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-12.2.1.tgz",
+      "integrity": "sha512-CpqulMQFwfkh/3J+TcizxQgXeTgIVhw8ZpYq4TU4uHoo1iSC8Xmyrfv2BHRNI1OWRQhCnpJXIWh5EzhpX24Fvw==",
       "dependencies": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -6576,7 +6576,7 @@
         "dotenv": "^8.2.0",
         "eventsource": "^1.0.7",
         "express": "^4.17.1",
-        "hbs": "^4.1.1",
+        "hbs": "^4.2.0",
         "ioredis": "^4.27.8",
         "js-yaml": "^3.14.1",
         "lru-cache": "^6.0.0",
@@ -14237,9 +14237,9 @@
       }
     },
     "probot": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-12.1.4.tgz",
-      "integrity": "sha512-pbvXXeZwIdi/vWk0Xtxe78ElDvczhzEzOjWjfxINyHCAA5cHaXF7+yX/bnDRZ9O0mEJB472H/NcMrT81Uy7kVg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-12.2.1.tgz",
+      "integrity": "sha512-CpqulMQFwfkh/3J+TcizxQgXeTgIVhw8ZpYq4TU4uHoo1iSC8Xmyrfv2BHRNI1OWRQhCnpJXIWh5EzhpX24Fvw==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -14263,7 +14263,7 @@
         "dotenv": "^8.2.0",
         "eventsource": "^1.0.7",
         "express": "^4.17.1",
-        "hbs": "^4.1.1",
+        "hbs": "^4.2.0",
         "ioredis": "^4.27.8",
         "js-yaml": "^3.14.1",
         "lru-cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "pino": "^6.11.0",
-    "probot": "^12.1.4",
+    "probot": "^12.2.1",
     "through2": "^4.0.2"
   }
 }


### PR DESCRIPTION
This should also include #36 which is another fix actual security for ansi-regex transitive dependency which was completely removed in #36 