### PR TITLE
fix(types): make run default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,4 @@ declare function run(
   probotApp: ApplicationFunction | ApplicationFunction[]
 ): Promise<void>;
 
-export = { run };
+export default run;


### PR DESCRIPTION
I made mistake in `export` in original declaration file.

Currently in TypeScript:
```ts
import run from "@probot/adapter-github-actions";
import app from "./app";

run.run(app);
```

This change will simplify calling of `run()` function:
```ts
import run from "@probot/adapter-github-actions";
import app from "./app";

run(app);
```