### PR TITLE
fix(README): Correct example filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ name: "Probot app name"
 description: "Probot app description."
 runs:
   using: "node12"
-  main: "action.js"
+  main: "index.js"
 ```
 
 **Important**: Your external dependencies will not be installed, you have to either vendor them in by committing the contents of the `node_modules` folder, or compile the code to a single executable script (recommended). See [GitHub's documentation](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#commit-tag-and-push-your-action-to-github)


### PR DESCRIPTION
I believe the readme has an erroneous reference to `action.js` which this PR corrects

-----
[View rendered README.md](https://github.com/zekenie/adapter-github-actions/blob/patch-1/README.md)